### PR TITLE
Fix duplicate target options + improve statebag useage

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,6 @@ If you want to add or modify a placeable item, follow the below instructions.
         - Optional Fields:
             - `customTargetOptions` - use this if you want to add more options than just picking up the item
             - `customPickupEvent` - use this if you want to add a custom event to be called when the item is picked up, rather than using the default handler
-            - `shouldUseItemNameState` - use this if you want to use the same prop model for multiple items.
-                - _AddTargetModel only supports one set of options per model, so this flag is necessary to use a statebag property instead._
     - If you want to put custom actions on the prop, then you will also need to include the `customTargetOptions`.
         ```lua
         local exampleCustomTargetOptions = {

--- a/client/placeables.lua
+++ b/client/placeables.lua
@@ -2,7 +2,7 @@ local animationDict = "pickup_object"
 local animation = "pickup_low"
 local isInPlaceItemMode = false
 
--- Keeps track of the models that have already been set with target options, ensuring we don't set create duplicate options for the same model
+-- Keeps track of the models that have already been set with target options, ensuring we don't create duplicate options for the same model
 -- In some frameworks like OX, if you create targetOptions on a model that already has it, it will append the options, whereas
 -- in QB it will override and only the last set of options will be used. We just need to add one option to the target model and then
 -- the pickup event will use the statebag to determine the correct item to give back to the player

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 
 description 'Waypoint Placeables'
 author 'BackSH00TER - Waypoint RP'
-version '1.0.6'
+version '1.1.0'
 
 shared_script {
     -- '@ox_lib/init.lua', -- Uncomment this if you are planning to integrate with any ox scripts

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -177,7 +177,6 @@ local chairCustomTargetOptions = {
 --- OPTIONAL FIELDS:
 ---@param customTargetOptions: Custom target options for this item, if it should do more than just pickup
 ---@param customPickupEvent: If you want to override the default pickup event, set this to the event you want to be called when the "pickup" target option is used
----@param shouldUseItemNameState: Only need to set this to true if you want to have multiple items use the same prop model. Otherwise you do not need to define it
 Config.PlaceableProps = {
     -- Constructions props
     {item = "roadworkbarrier", label = "Road Work Ahead Barrier", model = "prop_barrier_work04a", isFrozen = true},


### PR DESCRIPTION
- Renamed the statebag property from `itemNameOverride` to `itemName`
   - **This is a potential breaking change** for any scripts that were relying on this naming, as such bumped to v1.1.0

- Removes the need for `shouldUseItemNameState`. This was previously being used to optionally use a itemNameOverride statebag property on the entity. The primary purpose for doing this was that you can re-use the same prop model for several different items and when you pick up the prop, you need a way to know which item to give back to the player. 
   - Instead of optionally using the statebag, we now use it for all the props. The pickup event will now try to get the itemName from the statebag first and if its not defined then it falls back to getting the itemName from the targetOptions data (this should only happen on world spawned props, any placed props should have the statebags)

- Fixed issue with ox target options being duplicated for any model that was used more than once.
   -  If you define the same model twice with AddTargetModel:
    --      In qb-target, it will override the options, and the last one defined is used
    --      In ox_target, it will append the options, resulting in N duplicate options
  - To fix this we only allow creating the targetOptions once per model